### PR TITLE
Add provisional noop flows for mobile and portal apps

### DIFF
--- a/scripts/mobile-flow.js
+++ b/scripts/mobile-flow.js
@@ -1,0 +1,7 @@
+module.exports = function(runner) {
+  return function(previousResolution) {
+    runner.actStart('Mobile Flow');
+    runner.actEnd('Mobile Flow');
+    return Promise.resolve(previousResolution);
+  };
+};

--- a/scripts/portal-flow.js
+++ b/scripts/portal-flow.js
@@ -1,0 +1,7 @@
+module.exports = function(runner) {
+  return function(previousResolution) {
+    runner.actStart('Portal Flow');
+    runner.actEnd('Portal Flow');
+    return Promise.resolve(previousResolution);
+  };
+};


### PR DESCRIPTION
Just a skeleton to enable parallel execution of [RAINCATCH-580](https://issues.jboss.org/browse/RAINCATCH-580); [RAINCATCH-578](https://issues.jboss.org/browse/RAINCATCH-578); [RAINCATCH-579](https://issues.jboss.org/browse/RAINCATCH-579)