### PR TITLE
Loop for created workflow in setup script

### DIFF
--- a/scripts/mobile-flow.js
+++ b/scripts/mobile-flow.js
@@ -14,6 +14,17 @@ const acknowledge = require('../util/acknowledge');
 const recordUtils = require('../util/generate_record');
 const getCreatedRecord = require('../util/getCreatedRecord.js');
 
+/**
+ * Compare function to be used with getCreatedRecord.
+ * Searches for a record from a syncResponse in a syncRecords response.
+ */
+function findRecordByHash(expectedHash, syncResponse, syncRecordsResponse) {
+  const newAndUpdated = _.merge(_.get(syncRecordsResponse, 'res.create', {}),
+                                _.get(syncRecordsResponse, 'res.update', {}));
+  const expectedUid = _.get(_.find(syncResponse.updates.applied, {'hash': expectedHash}), 'uid');
+  return _.find(newAndUpdated, r => r.data.id === expectedUid);
+}
+
 module.exports = function mobileFlow(runner, argv, clientId) {
   return function mobileFlowAct(sessionToken) {
     runner.actStart('Mobile Flow');
@@ -71,7 +82,7 @@ module.exports = function mobileFlow(runner, argv, clientId) {
             const pending = [recordUtils.generateRecord(result, null, {}, 'create')];
             const payload = makeSyncBody('result', clientId, hashes.result, queryParams(user.id), pending, []);
             return create('result', hashes.result, payload, queryParams(user.id).result, [])
-              .then(res => getCreatedRecord(resultSyncRecords, res, clientRecs[datasets.indexOf('result')].clientRecs, pending[0].hash)
+              .then(res => getCreatedRecord(resultSyncRecords, res, clientRecs[datasets.indexOf('result')].clientRecs, findRecordByHash.bind(this, pending[0].hash))
                     .then(createdRecord => Promise.all([
                       Promise.resolve(createdRecord),
                       doAcknowledge('result', clientRecs[datasets.indexOf('result')].clientRecs, res)])
@@ -85,7 +96,7 @@ module.exports = function mobileFlow(runner, argv, clientId) {
               const pending = [recordUtils.generateRecord(result, createdRecord, {}, 'update')];
               const payload = makeSyncBody('result', clientId, hashes.result, queryParams(user.id), pending, []);
               return create('result', hashes.result, payload, queryParams(user.id).result, [])
-                .then(res => getCreatedRecord(resultSyncRecords, res, resultDatasetClientRecs, pending[0].hash)
+                .then(res => getCreatedRecord(resultSyncRecords, res, resultDatasetClientRecs, findRecordByHash.bind(this, pending[0].hash))
                       .then(createdRecord => Promise.all([
                         Promise.resolve(createdRecord),
                         doAcknowledge('result', resultDatasetClientRecs, res)])));


### PR DESCRIPTION
Currently when running the test script the setup script will break
the first time around. This is because it is expecting a newly created
workflow to definitely exist in the following `syncRecords` call. With
the new sync this might not be the case. Instead the setup script loops
a `syncRecords` call until it finds the correct workflow in the response.